### PR TITLE
fix: repeated application of no-dot/effect group swallowing comments

### DIFF
--- a/imports_builder.go
+++ b/imports_builder.go
@@ -61,21 +61,29 @@ func buildImportDecl(offset token.Pos, decl types.ImportDeclaration) (ast.Decl, 
 	// Ensure declaration starts from a new line.
 	newLines = append(newLines, offset)
 
-	// After adjusting the position move offset past the import keyword.
-	offset += token.Pos(len(token.IMPORT.String()))
-
 	// Handle single import case (no parenthesis should be added).
 	if len(decl.ImportGroups) == 1 && len(decl.ImportGroups[0].Specs) == 1 {
 		g := decl.ImportGroups[0]
 		s := g.Specs[0]
 		astSpec := copyImportSpec(s)
 
-		var astSpecDoc *ast.CommentGroup
-		if g.Doc != nil {
-			astSpecDoc = buildCombinedCommentGroup(offset, g.Doc.List)
+		// If the group has a doc comment but the spec doesn't, and the declaration doesn't have a doc,
+		// move the group's doc to the declaration's doc (so it appears before "import" keyword)
+		if astDecl.Doc == nil && astSpec.Doc == nil && g.Doc != nil {
+			astDecl.Doc = buildCombinedCommentGroup(offset, g.Doc.List)
+			newLines = buildCommentListNewlines(astDecl.Doc.List, newLines)
+			offset = astDecl.Doc.End() + 1
+			newLines = append(newLines, offset)
+
+			// Reposition the declaration to after the doc comment
+			astutils.ShiftGenDeclPos(offset-astDecl.Pos(), astDecl)
+			newLines = append(newLines, offset)
 		}
 
-		offset, newLines = buildImportSpec(offset, astSpec, astSpecDoc, newLines)
+		// After adjusting the position move offset past the import keyword.
+		offset += token.Pos(len(token.IMPORT.String()))
+
+		offset, newLines = buildImportSpec(offset, astSpec, nil, newLines)
 
 		// Populate the import declaration with adjusted specs.
 		astDecl.Specs = []ast.Spec{astSpec}
@@ -84,6 +92,9 @@ func buildImportDecl(offset token.Pos, decl types.ImportDeclaration) (ast.Decl, 
 		newLines = append(newLines, offset)
 		offset++
 	} else {
+		// After adjusting the position move offset past the import keyword.
+		offset += token.Pos(len(token.IMPORT.String()))
+
 		// Force add parenthesis if it does not exist.
 		astDecl.Lparen = offset
 		offset++

--- a/imports_test.go
+++ b/imports_test.go
@@ -110,8 +110,8 @@ func TestTestset00(t *testing.T) {
 
 func TestTestset01(t *testing.T) {
 	runTestSetFromFolder(t, "testdata/testset_exhaustive", ".go.in", ".go.out", func(testname TestName) types.ImportTransform {
-		switch testname {
-		case "noimports_hard_custom_transform":
+		switch {
+		case testname == "noimports_hard_custom_transform":
 			return func(decls []types.ImportDeclaration) []types.ImportDeclaration {
 				return []types.ImportDeclaration{
 					{
@@ -162,6 +162,10 @@ func TestTestset01(t *testing.T) {
 					},
 				}
 			}
+		case strings.HasPrefix(testname, "bugreport_3"):
+			return autogroup.New(
+				autogroup.WithSideEffectGroupEnabled(true),
+			)
 		}
 
 		return autogroup.New()

--- a/testdata/testset_exhaustive/bugreport_3.go.in
+++ b/testdata/testset_exhaustive/bugreport_3.go.in
@@ -1,0 +1,6 @@
+package my_package
+
+import (
+	// A comment justifying why we need this package
+	_ "github.com/jteeuwen/go-bindata/go-bindata"
+)

--- a/testdata/testset_exhaustive/bugreport_3.go.out
+++ b/testdata/testset_exhaustive/bugreport_3.go.out
@@ -1,0 +1,4 @@
+package my_package
+
+// A comment justifying why we need this package
+import _ "github.com/jteeuwen/go-bindata/go-bindata"


### PR DESCRIPTION
improves handling of comments in single entry import blocks making the fix operation idempotent and predictable

closes: #4