### PR TITLE
fixup(cli): ensure that --local flag is properly expanded

### DIFF
--- a/cmd/gofancyimports/main.go
+++ b/cmd/gofancyimports/main.go
@@ -193,11 +193,23 @@ func discoverPaths(path string, recursive bool) ([]string, error) {
 }
 
 func (c *fixCMD) runRewrite(srcPath string, srcOriginal []byte, isStdin bool) error {
+	// Expand comma-separated values in localPrefixes
+	var expandedPrefixes []string
+	for _, prefix := range c.localPrefixes {
+		// Split by comma and trim whitespace
+		parts := strings.Split(prefix, ",")
+		for _, part := range parts {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				expandedPrefixes = append(expandedPrefixes, trimmed)
+			}
+		}
+	}
+
 	transform := autogroup.New(
 		autogroup.WithSpecFixups(autogroup.FixupEmbedPackage),
 		autogroup.WithNoDotGroupEnabled(c.groupNoDot),
 		autogroup.WithSideEffectGroupEnabled(c.groupEffect),
-		autogroup.WithLocalPrefixGroup(c.localPrefixes),
+		autogroup.WithLocalPrefixGroup(expandedPrefixes),
 	)
 	srcRewritten, err := gofancyimports.RewriteImportsSource(
 		srcPath, srcOriginal,


### PR DESCRIPTION
* Now -l, --local flags indeed take comma separated list of prefixes
* Can still be specified multiple times

closes: #5